### PR TITLE
squid:S1118 - Utility classes should not have public constructors

### DIFF
--- a/rakam-aws-kinesis/src/main/java/org/rakam/aws/KinesisUtils.java
+++ b/rakam-aws-kinesis/src/main/java/org/rakam/aws/KinesisUtils.java
@@ -29,9 +29,13 @@ import java.util.List;
 /**
  * Utilities to create and delete Amazon Kinesis streams.
  */
-public class KinesisUtils {
+public final class KinesisUtils {
 
     private static Logger LOG = Logger.get(KinesisUtils.class);
+
+    private KinesisUtils() throws InstantiationException{
+        throw new InstantiationException("The class is not created for instantiation");
+    }
 
     /**
      * Creates an Amazon Kinesis stream if it does not exist and waits for it to become available

--- a/rakam-postgresql/src/main/java/org/rakam/postgresql/analysis/ReportAnalyzer.java
+++ b/rakam-postgresql/src/main/java/org/rakam/postgresql/analysis/ReportAnalyzer.java
@@ -13,7 +13,11 @@ import java.sql.Statement;
 import java.sql.Types;
 import java.time.format.DateTimeFormatter;
 
-public class ReportAnalyzer {
+public final class ReportAnalyzer {
+
+    private ReportAnalyzer() throws InstantiationException {
+        throw new InstantiationException("The class is not created for instantiation");
+    }
 
     public static ObjectNode execute(Connection conn, String sql) throws SQLException {
             Statement stmt = conn.createStatement();

--- a/rakam-spi/src/main/java/org/rakam/plugin/SystemEvents.java
+++ b/rakam-spi/src/main/java/org/rakam/plugin/SystemEvents.java
@@ -4,7 +4,12 @@ import org.rakam.collection.SchemaField;
 
 import java.util.List;
 
-public class SystemEvents {
+public final class SystemEvents {
+
+    private SystemEvents() throws InstantiationException {
+        throw new InstantiationException("The class is not created for instantiation");
+    }
+
     public static class ProjectCreatedEvent {
         public final String project;
 

--- a/rakam-spi/src/main/java/org/rakam/util/AvroUtil.java
+++ b/rakam-spi/src/main/java/org/rakam/util/AvroUtil.java
@@ -26,7 +26,12 @@ import java.util.stream.Collectors;
 import static org.apache.avro.Schema.Type.NULL;
 
 
-public class AvroUtil {
+public final class AvroUtil {
+
+    private AvroUtil() throws InstantiationException {
+        throw new InstantiationException("The class is not created for instantiation");
+    }
+
     public static Schema convertAvroSchema(Collection<SchemaField> fields) {
         List<Schema.Field> avroFields = fields.stream()
                 .map(AvroUtil::generateAvroSchema).collect(Collectors.toList());

--- a/rakam-spi/src/main/java/org/rakam/util/CryptUtil.java
+++ b/rakam-spi/src/main/java/org/rakam/util/CryptUtil.java
@@ -12,8 +12,10 @@ import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.util.Random;
 
-public class CryptUtil {
+public final class CryptUtil {
     static final Random random = new SecureRandom();
+
+    private CryptUtil() {}
 
     public static String generateRandomKey(int length) {
         String key;

--- a/rakam-spi/src/main/java/org/rakam/util/ValidationUtil.java
+++ b/rakam-spi/src/main/java/org/rakam/util/ValidationUtil.java
@@ -5,7 +5,12 @@ import io.netty.handler.codec.http.HttpResponseStatus;
 import javax.annotation.Nullable;
 
 
-public class ValidationUtil {
+public final class ValidationUtil {
+
+    private ValidationUtil() throws InstantiationException {
+        throw new InstantiationException("The class is not created for instantiation");
+    }
+
     public static void checkProject(String project) {
         checkArgument(project != null, "project is null");
         if(!project.matches("^[0-9A-Za-z_]+$")) {

--- a/rakam/src/main/java/org/rakam/ServiceStarter.java
+++ b/rakam/src/main/java/org/rakam/ServiceStarter.java
@@ -54,11 +54,15 @@ import static io.airlift.configuration.ConfigurationModule.bindConfig;
 import static java.lang.String.format;
 
 
-public class ServiceStarter {
+public final class ServiceStarter {
     // TODO: find a way to move this from here
     public static final String RAKAM_VERSION = "0.3";
 
     private final static Logger LOGGER = Logger.get(ServiceStarter.class);
+
+    private ServiceStarter() throws InstantiationException {
+        throw new InstantiationException("The class is not created for instantiation");
+    }
 
     public static void main(String[] args) throws Throwable {
         if (args.length > 0) {

--- a/rakam/src/main/java/org/rakam/SystemRegistryGenerator.java
+++ b/rakam/src/main/java/org/rakam/SystemRegistryGenerator.java
@@ -10,7 +10,11 @@ import java.io.PrintWriter;
 import java.util.Locale;
 import java.util.Set;
 
-public class SystemRegistryGenerator {
+public final class SystemRegistryGenerator {
+
+    private SystemRegistryGenerator() throws InstantiationException {
+        throw new InstantiationException("The class is not created for instantiation");
+    }
 
     public static void main(String[] args) throws IOException {
         if(args.length != 1 || !args[0].equals("json") && !args[0].equals("properties")) {

--- a/rakam/src/main/java/org/rakam/automation/ExpressionCompiler.java
+++ b/rakam/src/main/java/org/rakam/automation/ExpressionCompiler.java
@@ -20,7 +20,12 @@ import java.util.function.Predicate;
 
 import static org.rakam.util.ValidationUtil.checkTableColumn;
 
-public class ExpressionCompiler {
+public final class ExpressionCompiler {
+
+    private ExpressionCompiler() throws InstantiationException {
+        throw new InstantiationException("The class is not created for instantiation");
+    }
+
     public static Predicate<Event> compile(String expressionStr) throws UnsupportedOperationException {
         final Expression expression = new SqlParser().createExpression(expressionStr);
         final String javaExp = new JavaSourceAstVisitor().process(expression, false);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - Utility classes should not have public constructors

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1118

Please let me know if you have any questions.

M-Ezzat